### PR TITLE
Se agrega rel="noopener noreferrer"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -298,11 +298,10 @@
 
 
             <div class="social-bar">
-                <a href="https://www.facebook.com/MinisterioTIC.Colombia/" class="icon icon-facebook"
-                    target="_blank"></a>
-                <a href="https://twitter.com/Mineducacion" class="icon icon-twitter" target="_blank"></a>
-                <a href="https://www.youtube.com/user/minticolombia" class="icon icon-youtube" target="_blank"></a>
-                <a href="https://www.instagram.com/ministerio_tic/" class="icon icon-instagram" target="_blank"></a>
+                <a href="https://www.facebook.com/MinisterioTIC.Colombia/" class="icon icon-facebook" target="_blank" rel="noopener noreferrer"></a>
+                <a href="https://twitter.com/Mineducacion" class="icon icon-twitter" target="_blank" rel="noopener noreferrer"></a>
+                <a href="https://www.youtube.com/user/minticolombia" class="icon icon-youtube" target="_blank" rel="noopener noreferrer"></a>
+                <a href="https://www.instagram.com/ministerio_tic/" class="icon icon-instagram" target="_blank" rel="noopener noreferrer"></a>
             </div>
 
 


### PR DESCRIPTION
Para evita que la nueva página pueda acceder a la "window.opener" propiedad y garantiza que se ejecute en un proceso separado.  También evita que el Refererencabezado se envíe a la nueva página